### PR TITLE
Add initial unit tests

### DIFF
--- a/tests/test_bonuses.py
+++ b/tests/test_bonuses.py
@@ -1,0 +1,96 @@
+import importlib.util
+from types import SimpleNamespace
+from pathlib import Path
+import types
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Prepare fake db module to avoid importing psycopg2
+fake_db = types.ModuleType("db.db")
+class DummyConnection:
+    def select(self, *a, **k):
+        return {"result": []}
+    def disconnect(self):
+        pass
+    def updateFromStr(self, *a, **k):
+        pass
+fake_db.Connection = DummyConnection
+import sys
+sys.modules.setdefault("db", types.ModuleType("db"))
+sys.modules["db.db"] = fake_db
+
+
+def load_bonuses():
+    class LoaderConnection(DummyConnection):
+        def select(self, table, where_key="", where_value="", key="*"):
+            if table == "qualifications":
+                return {"result": [
+                    SimpleNamespace(line_bonus='{"lines": [10,5]}'),
+                    SimpleNamespace(line_bonus='{"lines": [5,3]}')
+                ]}
+            return super().select(table, where_key, where_value, key)
+
+    sys.modules["db.db"].Connection = LoaderConnection
+    spec = importlib.util.spec_from_file_location(
+        "bonuses", ROOT / "main" / "marketing" / "bonuses.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+class FakeConnection:
+    instances = []
+    def __init__(self):
+        self.inserts = []
+        FakeConnection.instances.append(self)
+    def select(self, table, where_key="", where_value="", key="*"):
+        if table == "qualifications":
+            return {"result": [SimpleNamespace(line_bonus='{"lines": [10,5]}'),
+                                SimpleNamespace(line_bonus='{"lines": [5,3]}')]}
+        if table == "user_data":
+            if int(where_value) == 2:
+                return {"result": SimpleNamespace(reffer_id=1)}
+            if int(where_value) == 1:
+                return {"result": SimpleNamespace(reffer_id=3)}
+            if int(where_value) == 3:
+                return {"result": SimpleNamespace(reffer_id=0)}
+        if table == "users":
+            val = int(where_value)
+            if val == 1:
+                return {"result": SimpleNamespace(id=1, uid="u1", qualification=2)}
+            if val == 2:
+                return {"result": SimpleNamespace(id=2, uid="u2", qualification=1)}
+            if val == 3:
+                return {"result": SimpleNamespace(id=3, uid="u3", qualification=2)}
+        if table == "packages":
+            return {"result": SimpleNamespace(bonus=True)}
+        return None
+    def insert(self, *args, **kwargs):
+        self.inserts.append((args, kwargs))
+    def update(self, *args, **kwargs):
+        pass
+    def selectWhereStr(self, s):
+        return []
+    def disconnect(self):
+        pass
+
+
+def test_pay_bonuses(monkeypatch):
+    bonuses = load_bonuses()
+    monkeypatch.setattr(bonuses, "Connection", FakeConnection)
+    FakeConnection.instances.clear()
+    user = SimpleNamespace(id=2, uid='u2', qualification=1)
+    bonuses.pay_bonuses(user, 100, 'init')
+    inserts = [ins for c in FakeConnection.instances for ins in c.inserts]
+    assert inserts
+    values = inserts[0][0][2]
+    assert 1 in values
+
+
+def test_ps_bonuses(monkeypatch):
+    bonuses = load_bonuses()
+    monkeypatch.setattr(bonuses, "Connection", FakeConnection)
+    FakeConnection.instances.clear()
+    user = SimpleNamespace(id=2, uid='u2', qualification=1)
+    bonuses.ps_bonuses(user, 100, 'init')
+    inserts = [ins for c in FakeConnection.instances for ins in c.inserts]
+    assert len(inserts) == 2

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -1,0 +1,60 @@
+import asyncio
+import asyncio
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "main"))
+sys.path.insert(0, str(ROOT))
+
+import types
+fake_db = types.ModuleType("db.db")
+class DummyConnection:
+    def select(self, *a, **k):
+        return {"result": []}
+    def disconnect(self):
+        pass
+    def updateFromStr(self, *a, **k):
+        pass
+fake_db.Connection = DummyConnection
+sys.modules.setdefault("db", types.ModuleType("db"))
+sys.modules["db.db"] = fake_db
+
+spec = importlib.util.spec_from_file_location(
+    "main_main", ROOT / "main" / "main.py")
+main_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(main_module)
+
+ConnectionManager = main_module.ConnectionManager
+clients = main_module.clients
+
+class FakeWebSocket:
+    def __init__(self):
+        self.accepted = False
+        self.sent = []
+        self.client_state = "CONNECTED"
+
+    async def accept(self):
+        self.accepted = True
+
+    async def send_text(self, message: str):
+        self.sent.append(message)
+
+
+async def run_manager():
+    manager = ConnectionManager()
+    ws = FakeWebSocket()
+    await manager.connect(ws, "uid1", 1)
+    assert ws in manager.active_connections
+    assert "uid1" in clients
+    await manager.send_personal_message("hello", ws)
+    assert ws.sent == ["hello"]
+    manager.disconnect(ws, "uid1")
+    assert ws not in manager.active_connections
+    assert "uid1" not in clients
+
+
+def test_connection_manager_event_loop():
+    asyncio.get_event_loop().run_until_complete(run_manager())

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -1,0 +1,30 @@
+import importlib.util
+import os
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+def load_jwt():
+    spec = importlib.util.spec_from_file_location(
+        "jwt_lib", ROOT / "main" / "lib" / "jwt.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+
+
+def test_create_and_verify_jwt(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "secret")
+    monkeypatch.setenv("ALGORITHM", "HS256")
+    jwt_lib = load_jwt()
+    token = jwt_lib.create_jwt_token({"sub": "user1"})
+    data = jwt_lib.verify_jwt_token(token)
+    assert data["sub"] == "user1"
+
+
+def test_verify_invalid_jwt(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "secret")
+    monkeypatch.setenv("ALGORITHM", "HS256")
+    jwt_lib = load_jwt()
+    assert jwt_lib.verify_jwt_token("invalid") is None


### PR DESCRIPTION
## Summary
- add unit tests for JWT utilities
- add unit tests for ConnectionManager behaviour
- add unit tests for marketing bonuses logic using fake DB

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68652a8cfe5c8320a824282d4ad39a6f